### PR TITLE
Brewfile: Don't need to tap caskroom/cask anymore

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,1 @@
-tap 'caskroom/cask'
-
 cask 'hammerspoon'


### PR DESCRIPTION
`brew cask` is available automatically in recent versions of Homebrew (and the caskroom org was merged into Homebrew as well).