### PR TITLE
send ESC for default amount of time

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -48,7 +48,7 @@ function obj:init()
         self.controlKeyTimer:start()
       else
         if self.sendEscape then
-          hs.eventtap.keyStroke({}, 'escape', 0)
+          hs.eventtap.keyStroke({}, 'escape')
         end
         self.lastModifiers = newModifiers
         self.controlKeyTimer:stop()


### PR DESCRIPTION
Sending ESC for 0 amount of time seems to break things that read the keyboard directly (like Alfred).

Leaving as the default seems to work better and matches the  [code in  the 'keyboard' project.](https://github.com/jasonrudolph/keyboard/blob/master/hammerspoon/control-escape.lua#L26)