### PR TITLE
changed escape delay to zero

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -48,7 +48,7 @@ function obj:init()
         self.controlKeyTimer:start()
       else
         if self.sendEscape then
-          hs.eventtap.keyStroke({}, 'escape', 0)
+          hs.eventtap.keyStroke({}, 'escape', 1)
         end
         self.lastModifiers = newModifiers
         self.controlKeyTimer:stop()

--- a/init.lua
+++ b/init.lua
@@ -48,7 +48,7 @@ function obj:init()
         self.controlKeyTimer:start()
       else
         if self.sendEscape then
-          hs.eventtap.keyStroke({}, 'escape')
+          hs.eventtap.keyStroke({}, 'escape', 0)
         end
         self.lastModifiers = newModifiers
         self.controlKeyTimer:stop()


### PR DESCRIPTION
Hammerspoon inserts a delay of 200ms (0.2ms) between keystrokes entered via `hs.eventtap.keyStroke` unless specified, which essentially causes a minor race condition with the 150ms controlKeyTimer when repeatedly pressing control. Aside from that, if we _know_ the user wants to send `Escape` (because `self.sendEscape` is `true`), we don't need a delay around the keystroke.

This removes that delay, and I can now spam `Escape` and get predictable results.