### PR TITLE
Minor script cleanup to avoid thinking there was a failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Brewfile.lock.json

--- a/script/setup
+++ b/script/setup
@@ -4,7 +4,7 @@ MINIMUM_HAMMERSPOON_VERSION=0.9.54
 
 set -e
 
-which -s brew || (echo "Homebrew is required: http://brew.sh/" && exit 1)
+command -v brew > /dev/null || (echo "Homebrew is required: http://brew.sh/" && exit 1)
 
 brew bundle check || brew bundle
 
@@ -25,9 +25,9 @@ open /Applications/Hammerspoon.app
 osascript -e 'tell application "System Events" to make login item at end with properties {path:"/Applications/Hammerspoon.app", hidden:true}' > /dev/null
 
 # Output Hammerspoon version
+CURRENT_VERSION=$(brew info hammerspoon | grep "hammerspoon:")
 echo
-echo "Hammerspoon version $MINIMUM_HAMMERSPOON_VERSION or greater required. Actual installed version:"
-brew cask info hammerspoon | grep "hammerspoon:"
+echo "Hammerspoon version $MINIMUM_HAMMERSPOON_VERSION or greater required. Actual installed version: $CURRENT_VERSION"
 echo
 
 echo "Done! Be sure to verify your version of Hammerspoon above. If your version is older than $MINIMUM_HAMMERSPOON_VERSION, run 'brew update && script/setup' to install a compatible version."


### PR DESCRIPTION
* Ignore Brewfile.lock.json
* Switch to more universal `command` over `which` (https://github.com/koalaman/shellcheck/wiki/SC2230)
* Grab Current Version of hammerspoon to display on same line as info line
* Update `brew info` command to use `--cask` instead of `brew info cask` which errors (the reason for this PR)

<details>
<summary>Original Output</summary>

```
❯ ./script/setup
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).
==> Updated Casks
Updated 1 cask.

The Brewfile's dependencies are satisfied.

Hammerspoon version 0.9.54 or greater required. Actual installed version:
Error: Calling brew cask info is disabled! Use brew info [--cask] instead.
```

</details>

<details>
<summary>New Output</summary>

```
❯ script/setup
The Brewfile's dependencies are satisfied.

Hammerspoon version 0.9.54 or greater required. Actual installed version: hammerspoon: 0.9.82 (auto_updates)

Done! Be sure to verify your version of Hammerspoon above. If your version is older than 0.9.54, run 'brew update && script/setup' to install a compatible version.
```

</details>