### PR TITLE
allow users to config the escape taptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,8 @@ Open *System Preferences*, navigate to *Keyboard > Modifier Keys*, and set the <
 You may find that sometimes your ControlEscape key does not result in an <kbd>escape</kbd>, and you have tap it a few times. By default, the <kbd>escape</kbd> key is emitted if you tap and release the ControlEscape key within 150ms, and your pinky may not be dexterous enough to meet this requirement. In this case, you can adjust the tapTime in your Hammerspoon config (commonly `~/.hammerspoon/init.lua`):
 
 ```lua
--- replace this
-hs.loadSpoon("ControlEscape"):start() -- Load Hammerspoon bits from https://github.com/jasonrudolph/ControlEscape.spoon
-
--- with
-control_escape = hs.loadSpoon("ControlEscape")
-control_escape.tapTime = 200 -- ms, making this number too high can make it hard to activate `control`
-control_escape:start() -- Load Hammerspoon bits from https://github.com/jasonrudolph/ControlEscape.spoon
+-- pass explicit tap time in milliseconds when calling :start(). making this number too high can make it hard to activate `control`
+hs.loadSpoon("ControlEscape"):start(200) -- ms
 ```
 
 Now you're ready to rock. 🤘

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ With one more bit of setup, you'll be able to hold <kbd>caps lock</kbd> for <kbd
 
 Open *System Preferences*, navigate to *Keyboard > Modifier Keys*, and set the <kbd>caps lock</kbd> key to <kbd>control</kbd>. [[screenshot]](https://user-images.githubusercontent.com/2988/27111039-7f620442-507b-11e7-9bcf-93d46e14af13.png)
 
+You may find that sometimes your ControlEscape key does not result in an <kbd>escape</kbd>, and you have tap it a few times. By default, the <kbd>escape</kbd> key is emitted if you tap and release the ControlEscape key within 150ms, and your pinky may not be dexterous enough to meet this requirement. In this case, you can adjust the tapTime in your Hammerspoon config (commonly `~/.hammerspoon/init.lua`):
+
+```lua
+-- replace this
+hs.loadSpoon("ControlEscape"):start() -- Load Hammerspoon bits from https://github.com/jasonrudolph/ControlEscape.spoon
+
+-- with
+control_escape = hs.loadSpoon("ControlEscape")
+control_escape.tapTime = 200 -- ms, making this number too high can make it hard to activate `control`
+control_escape:start() -- Load Hammerspoon bits from https://github.com/jasonrudolph/ControlEscape.spoon
+```
+
 Now you're ready to rock. 🤘
 
 ## Where can I get this code as a Spoon?

--- a/init.lua
+++ b/init.lua
@@ -18,6 +18,7 @@ obj.license = 'MIT - https://opensource.org/licenses/MIT'
 function obj:init()
   self.sendEscape = false
   self.lastModifiers = {}
+  -- self.timestamp = 0
 
   -- Create an eventtap to run each time the modifier keys change (i.e., each
   -- time a key like control, shift, option, or command is pressed or released)
@@ -40,9 +41,12 @@ function obj:init()
         self.lastModifiers = newModifiers
         self.sendEscape = true
         self.controlKeyTimer:start()
+        -- self.timestamp = hs.timer.absoluteTime()
       else
         if self.sendEscape then
           hs.eventtap.keyStroke({}, 'escape', 1)
+          -- print('escape sent after ' .. (hs.timer.absoluteTime() - self.timestamp) / 1000000 .. ' ms')
+          -- self.timestamp = 0
         end
         self.lastModifiers = newModifiers
         self.controlKeyTimer:stop()
@@ -70,6 +74,8 @@ function obj:start(tapTime)
   local CANCEL_DELAY_MS = tapTime or 150 -- ms, if `control` is held for this long, don't send `escape`
   self.controlKeyTimer = hs.timer.delayed.new(CANCEL_DELAY_MS / 1000, function()
     self.sendEscape = false
+    -- print('timer canceled after ' .. (hs.timer.absoluteTime() - self.timestamp) / 1000000 .. ' ms')
+    -- self.timestamp = 0
   end)
   self.controlTap:start()
   self.keyDownEventTap:start()

--- a/init.lua
+++ b/init.lua
@@ -17,11 +17,10 @@ obj.license = 'MIT - https://opensource.org/licenses/MIT'
 
 function obj:init()
   self.sendEscape = false
+  self.tapTime = 0.150 -- If `control` is held for this long, don't send `escape`
   self.lastModifiers = {}
 
-  -- If `control` is held for this long, don't send `escape`
-  local CANCEL_DELAY_SECONDS = 0.150
-  self.controlKeyTimer = hs.timer.delayed.new(CANCEL_DELAY_SECONDS, function()
+  self.controlKeyTimer = hs.timer.delayed.new(self.tapTime, function()
     self.sendEscape = false
   end)
 

--- a/init.lua
+++ b/init.lua
@@ -17,12 +17,7 @@ obj.license = 'MIT - https://opensource.org/licenses/MIT'
 
 function obj:init()
   self.sendEscape = false
-  self.tapTime = 0.150 -- If `control` is held for this long, don't send `escape`
   self.lastModifiers = {}
-
-  self.controlKeyTimer = hs.timer.delayed.new(self.tapTime, function()
-    self.sendEscape = false
-  end)
 
   -- Create an eventtap to run each time the modifier keys change (i.e., each
   -- time a key like control, shift, option, or command is pressed or released)
@@ -71,7 +66,11 @@ end
 --- ControlEscape:start()
 --- Method
 --- Start sending `escape` when `control` is pressed and released in isolation
-function obj:start()
+function obj:start(tapTime)
+  local CANCEL_DELAY_MS = tapTime or 150 -- ms, if `control` is held for this long, don't send `escape`
+  self.controlKeyTimer = hs.timer.delayed.new(CANCEL_DELAY_MS / 1000, function()
+    self.sendEscape = false
+  end)
   self.controlTap:start()
   self.keyDownEventTap:start()
 end


### PR DESCRIPTION
This allows Hammerspoon users to update the `escape` tap time in their config without meddling with the code of the Spoon itself